### PR TITLE
allocate array size in advance

### DIFF
--- a/src/merge-sorted.ts
+++ b/src/merge-sorted.ts
@@ -21,13 +21,12 @@ export default function mergeSorted<T>(
     comparator: (a: T, b: T) => number
 ): T[] {
 
-    const merged: T[] = []
+    const combinedLength = a.length + b.length
+    const merged: T[] = new Array(combinedLength)
 
     let indexA = 0
     let indexB = 0
     let current = 0
-
-    const combinedLength = a.length + b.length
 
     while (current < combinedLength) {
 


### PR DESCRIPTION
Hi!

This library has a performance issue. `merged` array is created with an empty size which causes memory allocation for each new element. This can be fixed by a simple patch.

Please see the benchmark https://jsperf.com/merge-sorted-array-size/1 - this fix makes the lib about 2x faster.